### PR TITLE
Significant Cleanups

### DIFF
--- a/async-requester/src/kino_local_handlers.rs
+++ b/async-requester/src/kino_local_handlers.rs
@@ -22,7 +22,7 @@ pub fn kino_local_handler(
     some_function();
 
     send_async!(
-        receiver_address(),
+        receiver_address_a(),
         AsyncRequest::StepA("Mashed Potatoes".to_string()),
         (resp, st: ProcessState) {
             on_step_a(resp, st);
@@ -52,7 +52,7 @@ fn on_step_a(response: i32, state: &mut ProcessState) {
     kiprintln!("Sender: State: {}", state.counter);
     state.counter += 1;
     send_async!(
-        receiver_address(),
+        receiver_address_a(),
         AsyncRequest::StepB(response),
         (resp, st: ProcessState) {
             let _ = on_step_b(resp, st);
@@ -65,7 +65,7 @@ fn on_step_b(response: u64, state: &mut ProcessState) -> anyhow::Result<()> {
     kiprintln!("Sender: State: {}", state.counter);
     state.counter += 1;
     send_async!(
-        receiver_address(),
+        receiver_address_a(),
         AsyncRequest::StepC(response),
         (resp, st: ProcessState) {
             on_step_c(resp, st);

--- a/async-requester/src/lib.rs
+++ b/async-requester/src/lib.rs
@@ -10,7 +10,7 @@ use kinode_process_lib::LazyLoadBlob;
 
 use kinode_app_common::erect;
 use kinode_app_common::State;
-use shared::receiver_address;
+use shared::receiver_address_a;
 use kinode_app_common::timer;
 
 use proc_macro_send::send_async;

--- a/lib/shared/src/lib.rs
+++ b/lib/shared/src/lib.rs
@@ -3,8 +3,8 @@ use kinode_process_lib::Address;
 use process_macros::SerdeJsonInto;
 use serde::{Deserialize, Serialize};
 
-pub fn receiver_address() -> Address {
-    ("our", "async-receiver", "async-app", "uncentered.os").into()
+pub fn receiver_address_a() -> Address {
+    ("our", "async-receiver-a", "async-app", "uncentered.os").into()
 }
 
 pub fn requester_address() -> Address {

--- a/pkg/manifest.json
+++ b/pkg/manifest.json
@@ -1,7 +1,7 @@
 [
     {
-        "process_name": "async-requester",
-        "process_wasm_path": "/async-requester.wasm",
+        "process_name": "async-receiver-a",
+        "process_wasm_path": "/async-receiver-a.wasm",
         "on_exit": "None",
         "request_networking": true,
         "request_capabilities": [
@@ -20,8 +20,48 @@
         "public": true
     },
     {
-        "process_name": "async-receiver",
-        "process_wasm_path": "/async-receiver.wasm",
+        "process_name": "async-receiver-b",
+        "process_wasm_path": "/async-receiver-b.wasm",
+        "on_exit": "None",
+        "request_networking": true,
+        "request_capabilities": [
+            "http-server:distro:sys",
+            "http-client:distro:sys",
+            "vfs:distro:sys",
+            "homepage:homepage:sys"
+
+        ],
+        "grant_capabilities": [
+            "http-server:distro:sys",
+            "http-client:distro:sys",
+            "vfs:distro:sys",
+            "homepage:homepage:sys"
+        ],
+        "public": true
+    },
+    {
+        "process_name": "async-receiver-c",
+        "process_wasm_path": "/async-receiver-c.wasm",
+        "on_exit": "None",
+        "request_networking": true,
+        "request_capabilities": [
+            "http-server:distro:sys",
+            "http-client:distro:sys",
+            "vfs:distro:sys",
+            "homepage:homepage:sys"
+
+        ],
+        "grant_capabilities": [
+            "http-server:distro:sys",
+            "http-client:distro:sys",
+            "vfs:distro:sys",
+            "homepage:homepage:sys"
+        ],
+        "public": true
+    },
+    {
+        "process_name": "async-requester",
+        "process_wasm_path": "/async-requester.wasm",
         "on_exit": "None",
         "request_networking": true,
         "request_capabilities": [


### PR DESCRIPTION
Given that we're single threaded, we can handle global state much easier. 

Also, the user state doesn't have to be in global state. 

Lots of function cleanups