### PR TITLE
Better setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,41 +1,127 @@
 # 🔥🚀🤘 Kinode Processes 2.0 🔥🚀🤘
 
-Shoutout to Doria (@dr-frmr) for the [initial app idea](https://github.com/kinode-dao/app-framework/tree/main), this is just a lot of sugar on top.
+Shoutout to Doria (@dr-frmr) for the initial app idea, this is just a lot of sugar on top.
 
-## How it Works
+## Overview
 
-### Erecting Apps
+Key Macros:
+
+- `erect!` – Defines and exports your process: name, icon, HTTP/WS endpoints, handlers, and initialization logic.
+- `declare_types!` – Declares strongly typed request/response enums for your message flows.
+- `send_async!` – Sends a request with an optional callback, timeout, and on-timeout behavior.
+- `fan_out!` – Sends multiple requests in parallel and aggregates their results into a single callback.
+- `timer!` – Creates a timer that will invoke a callback after a specified duration.
+
+## Declaring and Erecting Your App
+
+The `erect!` macro is your main entry point.
 
 ```rust
+use kinode_app_common::{erect, Binding, State};
+use kinode_process_lib::http::server::{HttpBindingConfig, WsBindingConfig};
+use kinode_process_lib::{Message, kiprintln};
+
+fn init_fn(state: &mut MyState) {
+    kiprintln!("Initializing My Cool Process!");
+    // Optionally schedule timers, run initial tasks, etc.
+}
+
+/// Example local handler for messages sent within the same node
+fn my_local_handler(
+    _message: &Message,
+    _state: &mut MyState,
+    _server: &mut kinode_process_lib::http::server::HttpServer,
+    request: SomeLocalRequestType,
+) {
+    kiprintln!("Received local request: {:?}", request);
+    // ...
+}
+
 erect!(
-    "Async Receiver",
-    None,
-    None,
-    http_handler,
-    kino_local_handler,
-    kino_remote_handler
+    // The name displayed in logs or UI
+    name: "My Cool Process",
+
+    // Optional icon for a GUI environment
+    icon: Some("icon-identifier"),
+
+    // Optional widget name for embedding in a UI
+    widget: None,
+
+    // Optional HTTP config for serving a UI at path "/"
+    ui: Some(HttpBindingConfig::default()),
+
+    // HTTP/WS endpoints
+    endpoints: [
+        Binding::Http {
+            path: "/api",
+            config: HttpBindingConfig::default(),
+        },
+        Binding::Ws {
+            path: "/ws",
+            config: WsBindingConfig::default(),
+        },
+    ],
+
+    // Handlers for different message classes
+    handlers: {
+        // For HTTP API calls
+        api: my_http_handler_function,
+
+        // For local (same-node) messages
+        local: my_local_handler,
+
+        // For remote messages (from other nodes)
+        remote: _,
+
+        // For WebSocket messages
+        ws: _,
+    },
+
+    // Initialization function
+    init: init_fn
 );
 ```
 
-The `erect!` macro takes several arguments in order:
+### Handler Parameters
 
-- The name of our process
-- The Icon (Optional)
-- The Widget of the process (Optional)
-- http_handler - function that handles incoming HTTP requests
-- kino_local_handler - handles messages from processes on the same node
-- kino_remote_handler - handles messages from other nodes
+Each handler receives:
 
-### Declaring Messaging Types
+- A Message object for raw metadata.
+- A mutable reference to your State.
+- A reference to the process’s HTTP server (so you can respond or manipulate connections).
+- A typed request object, which you define (e.g., SomeLocalRequestType).
+- Use `_` if you have no need for that particular type of message. Just make sure to at least declare one handler, or the macro will crash (and your process does nothing).
 
-For instance, take this:
+## Defining State
+
+Every process has some notion of application state. You define a struct that implements the State trait:
 
 ```rust
+#[derive(Debug, Serialize, Deserialize)]
+pub struct MyState {
+    pub counter: u64,
+}
+
+impl State for MyState {
+    fn new() -> Self {
+        Self { counter: 0 }
+    }
+}
+```
+
+## Declaring Messaging Types
+
+The declare_types! macro lets you define strongly typed request-response pairs. For example:
+
+```rust
+use kinode_app_common::declare_types;
+
 declare_types! {
     Async {
         StepA String => i32
         StepB i32 => u64
         StepC u64 => String
+        Gather () => Result<String, String>
     },
     Commodore {
         Power SomeStruct => SomeOtherStruct
@@ -44,150 +130,203 @@ declare_types! {
 }
 ```
 
-This will generate:
+This expands into something like:
 
 ```rust
-// Top level Request enum
-#[derive(Debug, Serialize, Deserialize, SerdeJsonInto, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub enum Req {
     Async(AsyncRequest),
     Commodore(CommodoreRequest),
 }
 
-// Async variant types
-#[derive(Debug, Serialize, Deserialize, SerdeJsonInto, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub enum AsyncRequest {
     StepA(String),
     StepB(i32),
     StepC(u64),
+    Gather(()),
 }
 
-#[derive(Debug, Serialize, Deserialize, SerdeJsonInto, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub enum AsyncResponse {
     StepA(i32),
     StepB(u64),
     StepC(String),
+    Gather(Result<String, String>),
 }
 
-// Commodore variant types
-#[derive(Debug, Serialize, Deserialize, SerdeJsonInto, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub enum CommodoreRequest {
     Power(SomeStruct),
     Excitement(i32),
 }
 
-#[derive(Debug, Serialize, Deserialize, SerdeJsonInto, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub enum CommodoreResponse {
     Power(SomeOtherStruct),
     Excitement(Result<String, String>),
 }
 ```
 
-This isn't just syntactic sugar, this will enforce that for each request, there is a corresponding response, and enforces naming schemes that will come in _extremely_ useful for the next macro.
+**Convention: If you define <Name>Request, the framework expects a corresponding <Name>Response. Each request variant has exactly one matching response variant, ensuring your callbacks get the right type automatically.**
 
-The naming scheme enforces these properties:
+## Async Sends
 
-- For every request variant, there is a only ONE response variant (with the same name).
-- Request enums always have the suffix `Request`, and Response enums always have the suffix `Response`.
+Once you have your request/response enums, you can easily invoke another process with send_async!. This macro:
 
-### Clean Async Sending
-
-If we have declared our messaging structs with the macro (or followed the conventions), we can easily send async messages like so:
-
-```rust
-send_async!(
-    receiver_address(),
-    AsyncRequest::StepA("Mashed Potatoes".to_string()),
-    (resp, st: AppState) {
-        on_step_a(resp, st);
-    },
-);
-```
-
-The compiler will _know_ what the value of resp is (i32 in this case).
-How cool is that???
-
-You can then chain calls, for example like this:
+- Serializes your request.
+- Sends it to the target address.
+- Registers a callback that is executed when the matching response arrives.
+- Optionally sets a timeout (in seconds).
+- Optionally runs an on_timeout block if no response is received in time.
+- Example (showing partial usage of optional timeout and callback):
 
 ```rust
-fn on_step_a(response: i32, state: &mut AppState) {
+use kinode_process_lib::Address;
+use proc_macro_send::send_async; // re-export from kinode_app_common
+
+fn message_a(state: &mut MyState) {
+    // We'll send "StepA" to the remote "Async Receiver A".
+    // If a response arrives before 20 seconds, run the callback block.
+    // If it times out, run the `on_timeout` block.
+    send_async!(
+        Address::new("our", "async-receiver-a", "async-app", "template.os"),
+        AsyncRequest::StepA("Mashed Potatoes".to_string()),
+        (resp, st: MyState) {
+            // This callback is invoked on success with the typed response
+            on_step_a(resp, st);
+        },
+        20,
+        on_timeout => {
+            kiprintln!("Request StepA timed out!");
+        }
+    );
+}
+
+fn on_step_a(response: i32, state: &mut MyState) {
     kiprintln!("Sender: Received response: {}", response);
     kiprintln!("Sender: State: {}", state.counter);
     state.counter += 1;
+
+    // Chain to Step B
     send_async!(
-        receiver_address(),
+        Address::new("our", "async-receiver-a", "async-app", "template.os"),
         AsyncRequest::StepB(response),
-        (resp, st: AppState) {
+        (resp, st: MyState) {
             on_step_b(resp, st);
         },
     );
 }
+
+fn on_step_b(response: u64, state: &mut MyState) {
+    kiprintln!("Sender: StepB response => {}", response);
+    state.counter += 1;
+    // ...
+}
 ```
 
-And then:
+## Fan-out / Aggregation
+
+Sometimes you want to send multiple requests in parallel, gather all responses, and then run a single callback. This is what the fan_out! macro does:
 
 ```rust
-fn on_step_b(response: u64, state: &mut AppState) {
-    kiprintln!("Sender: Received response: {}", response);
-    kiprintln!("Sender: State: {}", state.counter);
-    state.counter += 1;
-    send_async!(
-        receiver_address(),
-        AsyncRequest::StepC(response),
-        (resp, st: AppState) {
-            on_step_c(resp, st);
-        },
-    );
-}
+use kinode_app_common::fan_out;
+use kinode_process_lib::Address;
 
-fn on_step_c(response: String, state: &mut AppState) {
-    kiprintln!("Sender: Received response: {}", response);
-    kiprintln!("Sender: State: {}", state.counter);
-    state.counter += 1;
+fn fanout_message(state: &mut MyState) {
+    let addresses: Vec<Address> = vec![
+        Address::new("our", "async-receiver-a", "async-app", "template.os"),
+        Address::new("our", "async-receiver-b", "async-app", "template.os"),
+    ];
+
+    let requests: Vec<AsyncRequest> = vec![
+        AsyncRequest::Gather(()),
+        AsyncRequest::Gather(()),
+    ];
+
+    // We'll wait up to 5 seconds for each sub-request
+    fan_out!(
+        addresses,
+        requests,
+        (all_results, st: MyState) {
+            kiprintln!("Fan-out complete => subresponses: {:#?}", all_results);
+            st.counter += 1;
+        },
+        5
+    );
 }
 ```
 
-### Example Message Flow (yes, claude did this)
+Every request in requests is sent to the corresponding item in addresses.
+If a request times out or fails to send, it contributes an Err(...) to all_results.
+Once all requests are finished (or errored), the (all_results, st: MyState) { ... } block runs.
+
+## Timers
+
+Easily schedule recurring or one-off timers with the timer! macro. For example:
+
+```rust
+use kinode_app_common::timer;
+
+fn repeated_timer(state: &mut MyState) {
+    // Do something, e.g. log your current counter
+    kiprintln!("Timer fired! Counter = {}", state.counter);
+
+    // Maybe increment state
+    state.counter += 1;
+
+    // Schedule the next timer
+    timer!(3000, (st: MyState) {
+        // This block will run in 3 seconds
+        repeated_timer(st);
+    });
+}
+```
+
+## Example Flow
+
+My university teacher that hasn't produced anything meaningful in 25 years always told us that we should always draw diagrams. So here is a diagram.
 
 ```mermaid
 sequenceDiagram
-    participant TerminalProcess
-    participant RequesterProcess
-    participant ReceiverProcess
+    participant T as Terminal
+    participant R as Async Requester
+    participant Timer as Timer
+    participant A as Async Receiver A
+    participant B as Async Receiver B
+    participant C as Async Receiver C
+    participant X as Invalid Address
+    participant Y as Invalid Address
 
-    Note over TerminalProcess: m our@async-requester:async-app:template.os '"abc"'
-    TerminalProcess->>RequesterProcess: Terminal Command
+    %% Terminal triggers the requester (via a local handler)
+    T->>R: Terminal command ("abc")
+    Note over R: `kino_local_handler` triggers message_a()
 
-    rect rgb(70, 80, 120)
-        Note right of RequesterProcess: Step A
-        RequesterProcess->>+ReceiverProcess: AsyncRequest::StepA("Mashed Potatoes")
-        Note over ReceiverProcess: Sleep 3s
-        ReceiverProcess->>-RequesterProcess: AsyncResponse::StepA(length as i32)
-        Note over RequesterProcess: on_step_a callback
+    %% Chain of asynchronous sends (StepA -> StepB -> StepC) targeting Receiver A
+    R->>A: send AsyncRequest::StepA("Mashed Potatoes")
+    A-->>R: AsyncResponse::StepA(length)
+    R->>A: send AsyncRequest::StepB(response)
+    A-->>R: AsyncResponse::StepB(2 x response)
+    R->>A: send AsyncRequest::StepC(response)
+    A-->>R: AsyncResponse::StepC(String)
+
+    %% Repeated timer initiated in the Requester
+    Timer->>R: repeated timer tick\n(log & update counter)
+
+    %% Fan-out: Requester sends Gather requests to multiple addresses
+    Note over R: Fan-out: sending Gather requests
+    R->>A: AsyncRequest::Gather(())
+    R->>B: AsyncRequest::Gather(())
+    R->>C: AsyncRequest::Gather(())
+    R->>X: AsyncRequest::Gather(())    %% non-existent receiver
+    R->>Y: AsyncRequest::Gather(())    %% non-existent receiver
+
+    alt Aggregating Fan-Out Responses
+        A-->>R: AsyncResponse::Gather(Ok("Hello from A"))
+        B-->>R: AsyncResponse::Gather(Ok("Hello from B"))
+        C-->>R: AsyncResponse::Gather(Ok("Hello from C"))
+        X-->>R: Error/Timeout
+        Y-->>R: Error/Timeout
     end
-
-    rect rgb(70, 100, 70)
-        Note right of RequesterProcess: Step B
-        RequesterProcess->>+ReceiverProcess: AsyncRequest::StepB(response)
-        Note over ReceiverProcess: Sleep 3s
-        ReceiverProcess->>-RequesterProcess: AsyncResponse::StepB(val * 2)
-        Note over RequesterProcess: on_step_b callback
-    end
-
-    rect rgb(120, 70, 70)
-        Note right of RequesterProcess: Step C
-        RequesterProcess->>+ReceiverProcess: AsyncRequest::StepC(response)
-        Note over ReceiverProcess: Sleep 3s
-        ReceiverProcess->>-RequesterProcess: AsyncResponse::StepC("Hello from other side")
-        Note over RequesterProcess: on_step_c callback
-    end
-
-    Note over RequesterProcess: Final state.counter += 1
+    R->>R: Process aggregated results & update state
 ```
-
-### TODOs
-
-- Test test test and implement more processes.
-- Specify that a UI folder is needed if we initialize a ui, otherwise it fails silently.
-- Some features might have gotten lost since Dorias initial draft. Might have to bring a few back.
-- This will only work within rust for now. However, after using `declare_types!`, we could easily automatically generate a `.wit` file with a macro.

--- a/async-receiver-a/src/kino_local_handlers.rs
+++ b/async-receiver-a/src/kino_local_handlers.rs
@@ -26,9 +26,7 @@ pub fn kino_local_handler(
             kiprintln!("Receiver: Handling StepC");
             AsyncResponse::StepC(format!("Hello from the other side C: {}", u64_val))
         }
-        AsyncRequest::Gather(_) => {
-            AsyncResponse::Gather(Ok("Hello from A".to_string()))
-        },
+        AsyncRequest::Gather(_) => AsyncResponse::Gather(Ok("Hello from A".to_string())),
     };
 
     kiprintln!("Receiver: Sending response: {:?}", response_body);

--- a/async-receiver-a/src/lib.rs
+++ b/async-receiver-a/src/lib.rs
@@ -2,8 +2,7 @@ use kinode_process_lib::http::server::HttpServer;
 use kinode_process_lib::{kiprintln, Message};
 use serde::{Deserialize, Serialize};
 
-use kinode_app_common::erect;
-use kinode_app_common::State;
+use kinode_app_common::{erect, Binding, State};
 use kinode_process_lib::Response;
 use kinode_process_lib::http::server::{HttpBindingConfig, WsBindingConfig};
 mod kino_local_handlers;
@@ -24,17 +23,40 @@ fn init_fn(_state: &mut AppState) {
     kiprintln!("Initializing Async Receiver A");
 }
 
-erect!(
-    "Async Receiver A",
-    None,
-    None,
-    HttpBindingConfig::default(),
-    HttpBindingConfig::default(),
-    WsBindingConfig::default(),
-    _, // No HTTP API call
-    kino_local_handler,
-    _, // No remote request
-    _, // No WS handler
-    init_fn
-);
+// erect!(
+//     "Async Receiver A",
+//     None,
+//     None,
+//     HttpBindingConfig::default(),
+//     HttpBindingConfig::default(),
+//     WsBindingConfig::default(),
+//     _, // No HTTP API call
+//     kino_local_handler,
+//     _, // No remote request
+//     _, // No WS handler
+//     init_fn
+// );
 
+erect!(
+    name: "Async Receiver A",
+    icon: None,
+    widget: None,
+    ui: Some(HttpBindingConfig::default()),
+    endpoints: [
+        Binding::Http {
+            path: "/api",
+            config: HttpBindingConfig::default(),
+        },
+        Binding::Ws {
+            path: "/updates",
+            config: WsBindingConfig::default(),
+        },
+    ],
+    handlers: {
+        api: _,
+        local: kino_local_handler,
+        remote: _,
+        ws: _,
+    },
+    init: init_fn
+);

--- a/async-receiver-a/src/lib.rs
+++ b/async-receiver-a/src/lib.rs
@@ -3,8 +3,8 @@ use kinode_process_lib::{kiprintln, Message};
 use serde::{Deserialize, Serialize};
 
 use kinode_app_common::{erect, Binding, State};
-use kinode_process_lib::Response;
 use kinode_process_lib::http::server::{HttpBindingConfig, WsBindingConfig};
+use kinode_process_lib::Response;
 mod kino_local_handlers;
 mod structs;
 
@@ -22,20 +22,6 @@ wit_bindgen::generate!({
 fn init_fn(_state: &mut AppState) {
     kiprintln!("Initializing Async Receiver A");
 }
-
-// erect!(
-//     "Async Receiver A",
-//     None,
-//     None,
-//     HttpBindingConfig::default(),
-//     HttpBindingConfig::default(),
-//     WsBindingConfig::default(),
-//     _, // No HTTP API call
-//     kino_local_handler,
-//     _, // No remote request
-//     _, // No WS handler
-//     init_fn
-// );
 
 erect!(
     name: "Async Receiver A",

--- a/async-receiver-b/src/kino_local_handlers.rs
+++ b/async-receiver-b/src/kino_local_handlers.rs
@@ -26,9 +26,7 @@ pub fn kino_local_handler(
             kiprintln!("Receiver: Handling StepC");
             AsyncResponse::StepC(format!("Hello from the other side C: {}", u64_val))
         }
-        AsyncRequest::Gather(_) => {
-            AsyncResponse::Gather(Ok("Hello from B".to_string()))
-        },
+        AsyncRequest::Gather(_) => AsyncResponse::Gather(Ok("Hello from B".to_string())),
     };
 
     kiprintln!("Receiver: Sending response: {:?}", response_body);

--- a/async-receiver-b/src/lib.rs
+++ b/async-receiver-b/src/lib.rs
@@ -2,8 +2,7 @@ use kinode_process_lib::http::server::HttpServer;
 use kinode_process_lib::{kiprintln, Message};
 use serde::{Deserialize, Serialize};
 
-use kinode_app_common::erect;
-use kinode_app_common::State;
+use kinode_app_common::{erect, Binding, State};
 use kinode_process_lib::Response;
 use kinode_process_lib::http::server::{HttpBindingConfig, WsBindingConfig};
 mod kino_local_handlers;
@@ -24,17 +23,39 @@ fn init_fn(_state: &mut AppState) {
     kiprintln!("Initializing Async Receiver B");
 }
 
+// erect!(
+//     "Async Receiver B",
+//     None,
+//     None,
+//     HttpBindingConfig::default(),
+//     HttpBindingConfig::default(),
+//     WsBindingConfig::default(),
+//     _, // No HTTP API call
+//     kino_local_handler,
+//     _, // No remote request
+//     _, // No WS handler
+//     init_fn
+// );
 erect!(
-    "Async Receiver B",
-    None,
-    None,
-    HttpBindingConfig::default(),
-    HttpBindingConfig::default(),
-    WsBindingConfig::default(),
-    _, // No HTTP API call
-    kino_local_handler,
-    _, // No remote request
-    _, // No WS handler
-    init_fn
+    name: "Async Receiver B",
+    icon: None,
+    widget: None,
+    ui: Some(HttpBindingConfig::default()),
+    endpoints: [
+        Binding::Http {
+            path: "/api",
+            config: HttpBindingConfig::default(),
+        },
+        Binding::Ws {
+            path: "/updates",
+            config: WsBindingConfig::default(),
+        },
+    ],
+    handlers: {
+        api: _,
+        local: kino_local_handler,
+        remote: _,
+        ws: _,
+    },
+    init: init_fn
 );
-

--- a/async-receiver-b/src/lib.rs
+++ b/async-receiver-b/src/lib.rs
@@ -3,8 +3,8 @@ use kinode_process_lib::{kiprintln, Message};
 use serde::{Deserialize, Serialize};
 
 use kinode_app_common::{erect, Binding, State};
-use kinode_process_lib::Response;
 use kinode_process_lib::http::server::{HttpBindingConfig, WsBindingConfig};
+use kinode_process_lib::Response;
 mod kino_local_handlers;
 mod structs;
 
@@ -23,19 +23,6 @@ fn init_fn(_state: &mut AppState) {
     kiprintln!("Initializing Async Receiver B");
 }
 
-// erect!(
-//     "Async Receiver B",
-//     None,
-//     None,
-//     HttpBindingConfig::default(),
-//     HttpBindingConfig::default(),
-//     WsBindingConfig::default(),
-//     _, // No HTTP API call
-//     kino_local_handler,
-//     _, // No remote request
-//     _, // No WS handler
-//     init_fn
-// );
 erect!(
     name: "Async Receiver B",
     icon: None,

--- a/async-receiver-c/src/kino_local_handlers.rs
+++ b/async-receiver-c/src/kino_local_handlers.rs
@@ -26,9 +26,7 @@ pub fn kino_local_handler(
             kiprintln!("Receiver: Handling StepC");
             AsyncResponse::StepC(format!("Hello from the other side C: {}", u64_val))
         }
-        AsyncRequest::Gather(_) => {
-            AsyncResponse::Gather(Ok("Hello from C".to_string()))
-        },
+        AsyncRequest::Gather(_) => AsyncResponse::Gather(Ok("Hello from C".to_string())),
     };
 
     kiprintln!("Receiver: Sending response: {:?}", response_body);

--- a/async-receiver-c/src/lib.rs
+++ b/async-receiver-c/src/lib.rs
@@ -3,8 +3,8 @@ use kinode_process_lib::{kiprintln, Message};
 use serde::{Deserialize, Serialize};
 
 use kinode_app_common::{erect, Binding, State};
-use kinode_process_lib::Response;
 use kinode_process_lib::http::server::{HttpBindingConfig, WsBindingConfig};
+use kinode_process_lib::Response;
 mod kino_local_handlers;
 mod structs;
 
@@ -23,19 +23,6 @@ fn init_fn(_state: &mut AppState) {
     kiprintln!("Initializing Async Receiver C");
 }
 
-// erect!(
-//     "Async Receiver C",
-//     None,
-//     None,
-//     HttpBindingConfig::default(),
-//     HttpBindingConfig::default(),
-//     WsBindingConfig::default(),
-//     _, // No HTTP API call
-//     kino_local_handler,
-//     _, // No remote handler
-//     _, // No ws handler
-//     init_fn
-// );
 erect!(
     name: "Async Receiver C",
     icon: None,
@@ -59,4 +46,3 @@ erect!(
     },
     init: init_fn
 );
-

--- a/async-receiver-c/src/lib.rs
+++ b/async-receiver-c/src/lib.rs
@@ -2,8 +2,7 @@ use kinode_process_lib::http::server::HttpServer;
 use kinode_process_lib::{kiprintln, Message};
 use serde::{Deserialize, Serialize};
 
-use kinode_app_common::erect;
-use kinode_app_common::State;
+use kinode_app_common::{erect, Binding, State};
 use kinode_process_lib::Response;
 use kinode_process_lib::http::server::{HttpBindingConfig, WsBindingConfig};
 mod kino_local_handlers;
@@ -24,17 +23,40 @@ fn init_fn(_state: &mut AppState) {
     kiprintln!("Initializing Async Receiver C");
 }
 
+// erect!(
+//     "Async Receiver C",
+//     None,
+//     None,
+//     HttpBindingConfig::default(),
+//     HttpBindingConfig::default(),
+//     WsBindingConfig::default(),
+//     _, // No HTTP API call
+//     kino_local_handler,
+//     _, // No remote handler
+//     _, // No ws handler
+//     init_fn
+// );
 erect!(
-    "Async Receiver C",
-    None,
-    None,
-    HttpBindingConfig::default(),
-    HttpBindingConfig::default(),
-    WsBindingConfig::default(),
-    _, // No HTTP API call
-    kino_local_handler,
-    _, // No remote handler
-    _, // No ws handler
-    init_fn
+    name: "Async Receiver C",
+    icon: None,
+    widget: None,
+    ui: Some(HttpBindingConfig::default()),
+    endpoints: [
+        Binding::Http {
+            path: "/api",
+            config: HttpBindingConfig::default(),
+        },
+        Binding::Ws {
+            path: "/updates",
+            config: WsBindingConfig::default(),
+        },
+    ],
+    handlers: {
+        api: _,
+        local: kino_local_handler,
+        remote: _,
+        ws: _,
+    },
+    init: init_fn
 );
 

--- a/async-requester/src/helpers.rs
+++ b/async-requester/src/helpers.rs
@@ -1,6 +1,5 @@
 use crate::*;
 
-
 pub fn message_a() {
     send_async!(
         receiver_address_a(),

--- a/async-requester/src/lib.rs
+++ b/async-requester/src/lib.rs
@@ -2,12 +2,12 @@ use kinode_process_lib::http::server::HttpServer;
 use kinode_process_lib::{kiprintln, Message};
 use serde::{Deserialize, Serialize};
 
+use kinode_app_common::{erect, fan_out, timer, Binding, State};
 use kinode_process_lib::http::server::HttpBindingConfig;
 use kinode_process_lib::http::server::WsBindingConfig;
 use kinode_process_lib::Address;
-use kinode_app_common::{fan_out, Binding, erect, State, timer};
-use shared::receiver_address_a;
 use proc_macro_send::send_async;
+use shared::receiver_address_a;
 
 mod helpers;
 mod structs;
@@ -42,21 +42,6 @@ pub fn kino_local_handler(
 ) {
     message_a();
 }
-
-
-// erect!(
-//     "Async Requester",
-//     None,
-//     None,
-//     HttpBindingConfig::default(),
-//     HttpBindingConfig::default(),
-//     WsBindingConfig::default(),
-//     _, // No HTTP API call
-//     kino_local_handler,
-//     _, // No remote request
-//     _, // No WS handler
-//     init_fn
-// );
 
 erect!(
     name: "Async Requester",

--- a/crates/kinode_app_common/src/lib.rs
+++ b/crates/kinode_app_common/src/lib.rs
@@ -157,23 +157,43 @@ where
 }
 
 fn setup_server(
-    ui_config: &http::server::HttpBindingConfig,
-    api_config: &http::server::HttpBindingConfig,
-    ws_config: &http::server::WsBindingConfig,
+    ui_config: Option<&kinode_process_lib::http::server::HttpBindingConfig>,
+    endpoints: &[Binding],
 ) -> http::server::HttpServer {
     let mut server = http::server::HttpServer::new(5);
 
-    if let Err(e) = server.serve_ui("ui", vec!["/"], ui_config.clone()) {
-        panic!("failed to serve UI: {e}");
+    if let Some(ui) = ui_config {
+        if let Err(e) = server.serve_ui("ui", vec!["/"], ui.clone()) {
+            panic!("failed to serve UI: {e}");
+        }
     }
 
-    server
-        .bind_http_path("/api", api_config.clone())
-        .expect("failed to serve API path");
+    // Verify no duplicate paths
+    let mut seen_paths = std::collections::HashSet::new();
+    for endpoint in endpoints.iter() {
+        let path = match endpoint {
+            Binding::Http { path, .. } => path,
+            Binding::Ws { path, .. } => path,
+        };
+        if !seen_paths.insert(path) {
+            panic!("duplicate path found: {}", path);
+        }
+    }
 
-    server
-        .bind_ws_path("/updates", ws_config.clone())
-        .expect("failed to bind WS path");
+    for endpoint in endpoints {
+        match endpoint {
+            Binding::Http { path, config } => {
+                server
+                    .bind_http_path(path.to_string(), config.clone())
+                    .expect("failed to serve API path");
+            }
+            Binding::Ws { path, config } => {
+                server
+                    .bind_ws_path(path.to_string(), config.clone())
+                    .expect("failed to bind WS path");
+            }
+        }
+    }
 
     server
 }
@@ -252,9 +272,8 @@ pub fn app<S, T1, T2, T3>(
     app_name: &str,
     app_icon: Option<&str>,
     app_widget: Option<&str>,
-    ui_config: http::server::HttpBindingConfig,
-    api_config: http::server::HttpBindingConfig,
-    ws_config: http::server::WsBindingConfig,
+    ui_config: Option<kinode_process_lib::http::server::HttpBindingConfig>,
+    endpoints: Vec<Binding>,
     handle_api_call: impl Fn(&mut S, T1) -> (http::server::HttpResponse, Vec<u8>),
     handle_local_request: impl Fn(&Message, &mut S, &mut http::server::HttpServer, T2),
     handle_remote_request: impl Fn(&Message, &mut S, &mut http::server::HttpServer, T3),
@@ -280,7 +299,7 @@ where
         init_logging(Level::DEBUG, Level::INFO, None, Some((0, 0, 1, 1)), None).unwrap();
         info!("starting app");
 
-        let mut server = setup_server(&ui_config, &api_config, &ws_config);
+        let mut server = setup_server(ui_config.as_ref(), &endpoints);
         let mut user_state = initialize_state::<S>();
 
         // Execute the user specified init function
@@ -482,91 +501,103 @@ macro_rules! __check_not_all_empty {
     ($($any:tt)*) => {};
 }
 
-/// Creates and exports your Kinode microservice with all standard boilerplate.
-///
-/// **Parameters**:
-/// - `$app_name`: &str — The display name of your app.
-/// - `$app_icon`: Option<&str> — Icon path or `None`.
-/// - `$app_widget`: Option<&str> — Widget path or `None`.
-/// - `$ui_config`: `HttpBindingConfig` — config for the UI (pass `.default()` if not needed).
-/// - `$api_config`: `HttpBindingConfig` — config for the `/api` endpoint.
-/// - `$ws_config`: `WsBindingConfig` — config for the `/updates` path.
-/// - `$handle_api_call`, `$handle_local_request`, `$handle_remote_request`, `$handle_ws`:
-///   the 4 request-handling functions.
-/// - `$init_fn`: function `fn(&mut S)` called after setup, before the main loop.
-///
-/// **Example**:
-///
-/// ```ignore
-/// use kinode_process_lib::http::server::{HttpBindingConfig, WsBindingConfig};
-///
-/// fn handle_api_call(state: &mut MyState, req: MyRequest) -> (HttpResponse, Vec<u8>) {
-///     // ...
-/// }
-/// fn handle_local_request(_msg: &Message, _state: &mut MyState, _srv: &mut HttpServer, _req: MyLocal) { }
-/// fn handle_remote_request(_msg: &Message, _state: &mut MyState, _srv: &mut HttpServer, _req: MyRemote) { }
-/// fn handle_ws(_state: &mut MyState, _srv: &mut HttpServer, _id: u32, _typ: WsMessageType, _blob: LazyLoadBlob) { }
-///
-/// fn my_init_fn(state: &mut MyState) {
-///     // custom logic (timers, logs, etc.)
-/// }
-///
-/// erect!(
-///     "My App",
-///     Some("icon.png"),
-///     Some("widget_id"),
-///     HttpBindingConfig::default(), // config for serving UI
-///     HttpBindingConfig::default(), // config for /api
-///     WsBindingConfig::default(),   // config for /updates
-///     handle_api_call,
-///     handle_local_request,
-///     handle_remote_request,
-///     handle_ws,
-///     my_init_fn
-/// );
-/// ```
+// TODO: Zena: Generate new docs for this macro
 #[macro_export]
 macro_rules! erect {
     (
-        $app_name:expr,
-        $app_icon:expr,
-        $app_widget:expr,
-        $ui_config:expr,
-        $api_config:expr,
-        $ws_config:expr,
-        $handle_api_call:tt,
-        $handle_local_request:tt,
-        $handle_remote_request:tt,
-        $handle_ws:tt,
-        $init_fn:tt
+        name: $name:expr,
+        icon: $icon:expr,
+        widget: $widget:expr,
+        ui: $ui:expr,
+        endpoints: [ $($endpoints:expr),* $(,)? ],
+        handlers: {
+            api: $api:tt,
+            local: $local:tt,
+            remote: $remote:tt,
+            ws: $ws:tt,
+        },
+        init: $init:tt
+        $(,)?
     ) => {
-        // First check that not all handlers are empty
-        $crate::__check_not_all_empty!($handle_api_call, $handle_local_request, $handle_remote_request, $handle_ws, $init_fn);
+        $crate::__check_not_all_empty!($api, $local, $remote, $ws, $init);
+
+
 
         struct Component;
         impl Guest for Component {
             fn init(_our: String) {
                 use kinode_app_common::prelude::*;
 
-                let init_closure = $crate::app(
-                    $app_name,
-                    $app_icon,
-                    $app_widget,
-                    $ui_config,
-                    $api_config,
-                    $ws_config,
-                    $crate::__maybe!($handle_api_call => $crate::no_http_api_call),
-                    $crate::__maybe!($handle_local_request => $crate::no_local_request),
-                    $crate::__maybe!($handle_remote_request => $crate::no_remote_request),
-                    $crate::__maybe!($handle_ws => $crate::no_ws_handler),
-                    $crate::__maybe!($init_fn => $crate::no_init_fn),
+                // Map `_` to the appropriate fallback function
+                let handle_api_call = $crate::__maybe!($api => $crate::no_http_api_call);
+                let handle_local_request = $crate::__maybe!($local => $crate::no_local_request);
+                let handle_remote_request = $crate::__maybe!($remote => $crate::no_remote_request);
+                let handle_ws = $crate::__maybe!($ws => $crate::no_ws_handler);
+                let init_fn = $crate::__maybe!($init => $crate::no_init_fn);
+
+                // Build the vector of endpoints from user input
+                let endpoints_vec = vec![$($endpoints),*];
+
+                let closure = $crate::app(
+                    $name,
+                    $icon,
+                    $widget,
+                    $ui,
+                    endpoints_vec,
+                    handle_api_call,
+                    handle_local_request,
+                    handle_remote_request,
+                    handle_ws,
+                    init_fn,
                 );
-                init_closure();
+                closure();
             }
         }
         export!(Component);
     };
 }
+// #[macro_export]
+// macro_rules! erect {
+//     (
+//         $app_name:expr,
+//         $app_icon:expr,
+//         $app_widget:expr,
+//         $ui_config:expr,
+//         $api_config:expr,
+//         $ws_config:expr,
+//         $handle_api_call:tt,
+//         $handle_local_request:tt,
+//         $handle_remote_request:tt,
+//         $handle_ws:tt,
+//         $init_fn:tt
+//     ) => {
+//         // First check that not all handlers are empty
+//         $crate::__check_not_all_empty!($handle_api_call, $handle_local_request, $handle_remote_request, $handle_ws, $init_fn);
+
+//         struct Component;
+//         impl Guest for Component {
+//             fn init(_our: String) {
+//                 use kinode_app_common::prelude::*;
+
+//                 let init_closure = $crate::app(
+//                     $app_name,
+//                     $app_icon,
+//                     $app_widget,
+//                     $ui_config,
+//                     $api_config,
+//                     $ws_config,
+//                     $crate::__maybe!($handle_api_call => $crate::no_http_api_call),
+//                     $crate::__maybe!($handle_local_request => $crate::no_local_request),
+//                     $crate::__maybe!($handle_remote_request => $crate::no_remote_request),
+//                     $crate::__maybe!($handle_ws => $crate::no_ws_handler),
+//                     $crate::__maybe!($init_fn => $crate::no_init_fn),
+//                 );
+//                 init_closure();
+//             }
+//         }
+//         export!(Component);
+//     };
+// }
 
 #[doc(hidden)]
 #[macro_export]
@@ -623,7 +654,8 @@ pub fn aggregator_mark_result(
     i: usize,
     result: anyhow::Result<serde_json::Value>,
     user_state_any: &mut dyn Any,
-) { // Indentationmaxxing
+) {
+    // Indentationmaxxing
     HIDDEN_STATE.with(|cell| {
         if let Some(ref mut hidden) = *cell.borrow_mut() {
             if let Some(acc_any) = hidden.accumulators.get_mut(aggregator_id) {
@@ -760,10 +792,7 @@ pub fn no_ws_handler<S>(
     // does nothing
 }
 
-pub fn no_http_api_call<S>(
-    _state: &mut S,
-    _req: (),
-) -> (http::server::HttpResponse, Vec<u8>) {
+pub fn no_http_api_call<S>(_state: &mut S, _req: ()) -> (http::server::HttpResponse, Vec<u8>) {
     // trivial 200
     (http::server::HttpResponse::new(200 as u16), vec![])
 }
@@ -784,4 +813,16 @@ pub fn no_remote_request<S>(
     _req: (),
 ) {
     // does nothing
+}
+
+#[derive(Clone, Debug)]
+pub enum Binding {
+    Http {
+        path: &'static str,
+        config: kinode_process_lib::http::server::HttpBindingConfig,
+    },
+    Ws {
+        path: &'static str,
+        config: kinode_process_lib::http::server::WsBindingConfig,
+    },
 }

--- a/crates/proc_macro_send/src/lib.rs
+++ b/crates/proc_macro_send/src/lib.rs
@@ -1,9 +1,8 @@
 use proc_macro::TokenStream;
 use quote::quote;
 use syn::{
-    parse::Parse, parse::ParseStream, parse_macro_input, Block, Expr,
-    Expr::Call as ExprCallNode, Expr::Path as ExprPathNode, ExprCall, ExprPath,
-    Ident, Result, Token, Type,
+    parse::Parse, parse::ParseStream, parse_macro_input, Block, Expr, Expr::Call as ExprCallNode,
+    Expr::Path as ExprPathNode, ExprCall, ExprPath, Ident, Result, Token, Type,
 };
 
 /// The main macro entry point
@@ -78,10 +77,7 @@ impl Parse for SendAsyncInvocation {
                     if input.peek(Token![,]) {
                         input.parse::<Token![,]>()?;
                     }
-
-                } else if input.peek(syn::LitInt)
-                    || input.peek(syn::Lit)
-                    || input.peek(syn::Ident)
+                } else if input.peek(syn::LitInt) || input.peek(syn::Lit) || input.peek(syn::Ident)
                 {
                     // Probably the timeout expression
                     if timeout.is_none() {
@@ -94,7 +90,6 @@ impl Parse for SendAsyncInvocation {
                     if input.peek(Token![,]) {
                         input.parse::<Token![,]>()?;
                     }
-
                 } else if input.peek(Ident) {
                     // Possibly `on_timeout => { ... }`
                     let ident: Ident = input.parse()?;


### PR DESCRIPTION
You can now call the macro like this: 

```rust
erect!(
    name: "Async Receiver A",
    icon: None,
    widget: None,
    ui: Some(HttpBindingConfig::default()),
    endpoints: [
        Binding::Http {
            path: "/api",
            config: HttpBindingConfig::default(),
        },
        Binding::Ws {
            path: "/updates",
            config: WsBindingConfig::default(),
        },
    ],
    handlers: {
        api: _,
        local: kino_local_handler,
        remote: _,
        ws: _,
    },
    init: init_fn
);
```