### PR TITLE
Quality of Life Changes

### DIFF
--- a/async-receiver-a/src/lib.rs
+++ b/async-receiver-a/src/lib.rs
@@ -12,13 +12,6 @@ use kino_local_handlers::*;
 use shared::*;
 use structs::*;
 
-wit_bindgen::generate!({
-    path: "target/wit",
-    world: "async-app-template-dot-os-v0",
-    generate_unused_types: true,
-    additional_derives: [serde::Deserialize, serde::Serialize, process_macros::SerdeJsonInto],
-});
-
 fn init_fn(_state: &mut AppState) {
     kiprintln!("Initializing Async Receiver A");
 }
@@ -33,10 +26,6 @@ erect!(
             path: "/api",
             config: HttpBindingConfig::default(),
         },
-        Binding::Ws {
-            path: "/updates",
-            config: WsBindingConfig::default(),
-        },
     ],
     handlers: {
         api: _,
@@ -44,5 +33,6 @@ erect!(
         remote: _,
         ws: _,
     },
-    init: init_fn
+    init: init_fn,
+    wit_world: "async-app-template-dot-os-v0"
 );

--- a/async-receiver-a/src/lib.rs
+++ b/async-receiver-a/src/lib.rs
@@ -3,7 +3,7 @@ use kinode_process_lib::{kiprintln, Message};
 use serde::{Deserialize, Serialize};
 
 use kinode_app_common::{erect, Binding, State};
-use kinode_process_lib::http::server::{HttpBindingConfig, WsBindingConfig};
+use kinode_process_lib::http::server::HttpBindingConfig;
 use kinode_process_lib::Response;
 mod kino_local_handlers;
 mod structs;
@@ -28,7 +28,7 @@ erect!(
         },
     ],
     handlers: {
-        api: _,
+        http: _,
         local: kino_local_handler,
         remote: _,
         ws: _,

--- a/async-receiver-b/src/lib.rs
+++ b/async-receiver-b/src/lib.rs
@@ -12,13 +12,6 @@ use kino_local_handlers::*;
 use shared::*;
 use structs::*;
 
-wit_bindgen::generate!({
-    path: "target/wit",
-    world: "async-app-template-dot-os-v0",
-    generate_unused_types: true,
-    additional_derives: [serde::Deserialize, serde::Serialize, process_macros::SerdeJsonInto],
-});
-
 fn init_fn(_state: &mut AppState) {
     kiprintln!("Initializing Async Receiver B");
 }
@@ -33,10 +26,6 @@ erect!(
             path: "/api",
             config: HttpBindingConfig::default(),
         },
-        Binding::Ws {
-            path: "/updates",
-            config: WsBindingConfig::default(),
-        },
     ],
     handlers: {
         api: _,
@@ -44,5 +33,6 @@ erect!(
         remote: _,
         ws: _,
     },
-    init: init_fn
+    init: init_fn,
+    wit_world: "async-app-template-dot-os-v0"
 );

--- a/async-receiver-b/src/lib.rs
+++ b/async-receiver-b/src/lib.rs
@@ -3,7 +3,7 @@ use kinode_process_lib::{kiprintln, Message};
 use serde::{Deserialize, Serialize};
 
 use kinode_app_common::{erect, Binding, State};
-use kinode_process_lib::http::server::{HttpBindingConfig, WsBindingConfig};
+use kinode_process_lib::http::server::HttpBindingConfig;
 use kinode_process_lib::Response;
 mod kino_local_handlers;
 mod structs;
@@ -28,7 +28,7 @@ erect!(
         },
     ],
     handlers: {
-        api: _,
+        http: _,
         local: kino_local_handler,
         remote: _,
         ws: _,

--- a/async-receiver-c/src/lib.rs
+++ b/async-receiver-c/src/lib.rs
@@ -12,13 +12,6 @@ use kino_local_handlers::*;
 use shared::*;
 use structs::*;
 
-wit_bindgen::generate!({
-    path: "target/wit",
-    world: "async-app-template-dot-os-v0",
-    generate_unused_types: true,
-    additional_derives: [serde::Deserialize, serde::Serialize, process_macros::SerdeJsonInto],
-});
-
 fn init_fn(_state: &mut AppState) {
     kiprintln!("Initializing Async Receiver C");
 }
@@ -33,10 +26,6 @@ erect!(
             path: "/api",
             config: HttpBindingConfig::default(),
         },
-        Binding::Ws {
-            path: "/updates",
-            config: WsBindingConfig::default(),
-        },
     ],
     handlers: {
         api: _,
@@ -44,5 +33,6 @@ erect!(
         remote: _,
         ws: _,
     },
-    init: init_fn
+    init: init_fn,
+    wit_world: "async-app-template-dot-os-v0"
 );

--- a/async-receiver-c/src/lib.rs
+++ b/async-receiver-c/src/lib.rs
@@ -3,7 +3,7 @@ use kinode_process_lib::{kiprintln, Message};
 use serde::{Deserialize, Serialize};
 
 use kinode_app_common::{erect, Binding, State};
-use kinode_process_lib::http::server::{HttpBindingConfig, WsBindingConfig};
+use kinode_process_lib::http::server::HttpBindingConfig;
 use kinode_process_lib::Response;
 mod kino_local_handlers;
 mod structs;
@@ -28,7 +28,7 @@ erect!(
         },
     ],
     handlers: {
-        api: _,
+        http: _,
         local: kino_local_handler,
         remote: _,
         ws: _,

--- a/async-requester/src/lib.rs
+++ b/async-requester/src/lib.rs
@@ -6,6 +6,7 @@ use kinode_app_common::{erect, fan_out, timer, Binding, State};
 use kinode_process_lib::http::server::HttpBindingConfig;
 use kinode_process_lib::Address;
 use proc_macro_send::send_async;
+use serde_json::Value;
 use shared::receiver_address_a;
 
 mod helpers;
@@ -37,10 +38,11 @@ pub fn kino_local_handler(
 
 fn http_handler(
     _state: &mut ProcessState,
-    _path: &str,
-    _request: String,
+    path: &str,
+    req: Value,
 ) {
-    kiprintln!("Received HTTP request: {}", _request);
+    kiprintln!("Received HTTP request: {:#?}", req);
+    kiprintln!("Path is {:#?}", path);
 }
 
 erect!(
@@ -51,7 +53,7 @@ erect!(
     endpoints: [
         Binding::Http {
             path: "/api",
-            config: HttpBindingConfig::default(),
+            config: HttpBindingConfig::new(false, false, false, None),
         },
     ],
     handlers: {
@@ -64,4 +66,7 @@ erect!(
     wit_world: "async-app-template-dot-os-v0"
 );
 
-// m our@async-requester:async-app:template.os '"abc"'
+/*
+m our@async-requester:async-app:template.os '"abc"'
+curl -X POST -H "Content-Type: application/json" -d '{"message": "hello world"}' http://localhost:8080/async-requester:async-app:uncentered.os/api
+*/

--- a/async-requester/src/lib.rs
+++ b/async-requester/src/lib.rs
@@ -47,7 +47,7 @@ erect!(
         },
     ],
     handlers: {
-        api: _,
+        http: _,
         local: kino_local_handler,
         remote: _,
         ws: _,

--- a/async-requester/src/lib.rs
+++ b/async-requester/src/lib.rs
@@ -4,7 +4,6 @@ use serde::{Deserialize, Serialize};
 
 use kinode_app_common::{erect, fan_out, timer, Binding, State};
 use kinode_process_lib::http::server::HttpBindingConfig;
-use kinode_process_lib::http::server::WsBindingConfig;
 use kinode_process_lib::Address;
 use proc_macro_send::send_async;
 use shared::receiver_address_a;
@@ -15,13 +14,6 @@ mod structs;
 use helpers::*;
 use shared::*;
 use structs::*;
-
-wit_bindgen::generate!({
-    path: "target/wit",
-    world: "async-app-template-dot-os-v0",
-    generate_unused_types: true,
-    additional_derives: [serde::Deserialize, serde::Serialize, process_macros::SerdeJsonInto],
-});
 
 fn init_fn(state: &mut ProcessState) {
     kiprintln!("Initializing Async Requester");
@@ -53,10 +45,6 @@ erect!(
             path: "/api",
             config: HttpBindingConfig::default(),
         },
-        Binding::Ws {
-            path: "/updates",
-            config: WsBindingConfig::default(),
-        },
     ],
     handlers: {
         api: _,
@@ -64,7 +52,8 @@ erect!(
         remote: _,
         ws: _,
     },
-    init: init_fn
+    init: init_fn,
+    wit_world: "async-app-template-dot-os-v0"
 );
 
 // m our@async-requester:async-app:template.os '"abc"'

--- a/async-requester/src/lib.rs
+++ b/async-requester/src/lib.rs
@@ -35,6 +35,14 @@ pub fn kino_local_handler(
     message_a();
 }
 
+fn http_handler(
+    _state: &mut ProcessState,
+    _path: &str,
+    _request: String,
+) {
+    kiprintln!("Received HTTP request: {}", _request);
+}
+
 erect!(
     name: "Async Requester",
     icon: None,
@@ -47,7 +55,7 @@ erect!(
         },
     ],
     handlers: {
-        http: _,
+        http: http_handler,
         local: kino_local_handler,
         remote: _,
         ws: _,

--- a/crates/kinode_app_common/src/lib.rs
+++ b/crates/kinode_app_common/src/lib.rs
@@ -573,7 +573,7 @@ macro_rules! __check_not_all_empty {
 ///         },
 ///     ],
 ///     handlers: {
-///         api: _, // The handler for HTTP API calls
+///         http: _, // The handler for HTTP API calls
 ///         local: kino_local_handler, // The handler for local kinode messages
 ///         remote: _, // The handler for remote kinode messages
 ///         ws: _, // The websocket handler
@@ -598,7 +598,7 @@ macro_rules! erect {
         ui: $ui:expr,
         endpoints: [ $($endpoints:expr),* $(,)? ],
         handlers: {
-            api: $api:tt,
+            http: $http:tt,
             local: $local:tt,
             remote: $remote:tt,
             ws: $ws:tt,
@@ -620,7 +620,7 @@ macro_rules! erect {
             ],
         });
 
-        $crate::__check_not_all_empty!($api, $local, $remote, $ws, $init);
+        $crate::__check_not_all_empty!($http, $local, $remote, $ws, $init);
 
         struct Component;
         impl Guest for Component {
@@ -628,7 +628,7 @@ macro_rules! erect {
                 use kinode_app_common::prelude::*;
 
                 // Map `_` to the appropriate fallback function
-                let handle_api_call = $crate::__maybe!($api => $crate::no_http_api_call);
+                let handle_http_api_call = $crate::__maybe!($http => $crate::no_http_api_call);
                 let handle_local_request = $crate::__maybe!($local => $crate::no_local_request);
                 let handle_remote_request = $crate::__maybe!($remote => $crate::no_remote_request);
                 let handle_ws = $crate::__maybe!($ws => $crate::no_ws_handler);
@@ -643,7 +643,7 @@ macro_rules! erect {
                     $widget,
                     $ui,
                     endpoints_vec,
-                    handle_api_call,
+                    handle_http_api_call,
                     handle_local_request,
                     handle_remote_request,
                     handle_ws,

--- a/crates/kinode_app_common/src/lib.rs
+++ b/crates/kinode_app_common/src/lib.rs
@@ -355,7 +355,9 @@ fn http_request<S, T1>(
                 return;
             };
             let Ok(deserialized_struct) = serde_json::from_slice::<T1>(blob.bytes()) else {
-                warn!("Failed to deserialize Http request into struct, exiting");
+                let body_str = String::from_utf8_lossy(blob.bytes());
+                warn!("Raw request body was: {:#?}", body_str);
+                warn!("Failed to deserialize into type parameter T1 (type: {}), check that the request body matches this type's structure", std::any::type_name::<T1>());
                 return;
             };
 

--- a/crates/kinode_app_common/src/lib.rs
+++ b/crates/kinode_app_common/src/lib.rs
@@ -394,6 +394,10 @@ fn local_request<S, T>(
     let Ok(request) = serde_json::from_slice::<T>(message.body()) else {
         if message.body() == b"debug" {
             kiprintln!("state:\n{:#?}", state);
+        } else {
+            warn!("Failed to deserialize local request into struct, exiting");
+            let body_str = String::from_utf8_lossy(message.body());
+            warn!("Raw request body was: {:#?}", body_str);
         }
         return;
     };
@@ -409,6 +413,9 @@ fn remote_request<S, T>(
     T: serde::Serialize + serde::de::DeserializeOwned,
 {
     let Ok(request) = serde_json::from_slice::<T>(message.body()) else {
+        warn!("Failed to deserialize remote request into struct, exiting");
+        let body_str = String::from_utf8_lossy(message.body());
+        warn!("Raw request body was: {:#?}", body_str);
         return;
     };
     handle_remote_request(message, state, server, request);

--- a/crates/kinode_app_common/src/lib.rs
+++ b/crates/kinode_app_common/src/lib.rs
@@ -2,11 +2,12 @@ use kinode_process_lib::get_state;
 use kinode_process_lib::http::server::WsMessageType;
 use kinode_process_lib::logging::info;
 use kinode_process_lib::logging::init_logging;
+use kinode_process_lib::logging::warn;
 use kinode_process_lib::logging::Level;
 use std::any::Any;
 use std::collections::HashMap;
-
 use std::cell::RefCell;
+use kinode_process_lib::http::server::HttpServerRequest;
 
 use kinode_process_lib::{
     await_message, homepage, http, kiprintln, set_state, LazyLoadBlob, Message, SendError,
@@ -202,7 +203,7 @@ fn handle_message<S, T1, T2, T3>(
     message: Message,
     user_state: &mut S,
     server: &mut http::server::HttpServer,
-    handle_api_call: &impl Fn(&mut S, T1) -> (http::server::HttpResponse, Vec<u8>),
+    handle_api_call: &impl Fn(&mut S, &str, T1),
     handle_local_request: &impl Fn(&Message, &mut S, &mut http::server::HttpServer, T2),
     handle_remote_request: &impl Fn(&Message, &mut S, &mut http::server::HttpServer, T3),
     handle_ws: &impl Fn(&mut S, &mut http::server::HttpServer, u32, WsMessageType, LazyLoadBlob),
@@ -274,7 +275,7 @@ pub fn app<S, T1, T2, T3>(
     app_widget: Option<&str>,
     ui_config: Option<kinode_process_lib::http::server::HttpBindingConfig>,
     endpoints: Vec<Binding>,
-    handle_api_call: impl Fn(&mut S, T1) -> (http::server::HttpResponse, Vec<u8>),
+    handle_api_call: impl Fn(&mut S, &str, T1),
     handle_local_request: impl Fn(&Message, &mut S, &mut http::server::HttpServer, T2),
     handle_remote_request: impl Fn(&Message, &mut S, &mut http::server::HttpServer, T3),
     handle_ws: impl Fn(&mut S, &mut http::server::HttpServer, u32, WsMessageType, LazyLoadBlob),
@@ -334,7 +335,7 @@ fn http_request<S, T1>(
     message: &Message,
     state: &mut S,
     server: &mut http::server::HttpServer,
-    handle_api_call: impl Fn(&mut S, T1) -> (http::server::HttpResponse, Vec<u8>),
+    handle_api_call: impl Fn(&mut S, &str, T1),
     handle_ws: impl Fn(&mut S, &mut http::server::HttpServer, u32, WsMessageType, LazyLoadBlob),
 ) where
     T1: serde::Serialize + serde::de::DeserializeOwned,
@@ -342,36 +343,41 @@ fn http_request<S, T1>(
     let http_request = serde_json::from_slice::<http::server::HttpServerRequest>(message.body())
         .expect("failed to parse HTTP request");
 
-    let state_ptr: *mut S = state;
-    let server_ptr: *mut http::server::HttpServer = server;
 
-    server.handle_request(
-        http_request,
-        move |_incoming| {
-            let state_ref: &mut S = unsafe { &mut *state_ptr };
-
-            let response = http::server::HttpResponse::new(200 as u16);
+    match http_request {
+        HttpServerRequest::Http(http_request) => {
+            let Ok(path) = http_request.path() else {
+                warn!("Failed to get path for Http, exiting, this should never happen");
+                return;
+            };
             let Some(blob) = message.blob() else {
-                return (response.set_status(400), None);
+                warn!("Failed to get blob for Http, exiting");
+                return;
             };
-            let Ok(call) = serde_json::from_slice::<T1>(blob.bytes()) else {
-                return (response.set_status(400), None);
+            let Ok(deserialized_struct) = serde_json::from_slice::<T1>(blob.bytes()) else {
+                warn!("Failed to deserialize Http request into struct, exiting");
+                return;
             };
 
-            let (response, bytes) = handle_api_call(state_ref, call);
-
-            (
-                response,
-                Some(LazyLoadBlob::new(Some("application/json"), bytes)),
-            )
-        },
-        move |channel_id, msg_type, blob| {
-            let state_ref: &mut S = unsafe { &mut *state_ptr };
-            let server_ref: &mut http::server::HttpServer = unsafe { &mut *server_ptr };
-
-            handle_ws(state_ref, server_ref, channel_id, msg_type, blob);
-        },
-    );
+            handle_api_call(state, &path, deserialized_struct);
+        }
+        HttpServerRequest::WebSocketPush {
+            channel_id,
+            message_type,
+        } => {
+            let Some(blob) = message.blob() else {
+                warn!("Failed to get blob for WebSocketPush, exiting");
+                return;
+            };
+            handle_ws(state, server, channel_id, message_type, blob)
+        }
+        HttpServerRequest::WebSocketOpen { path, channel_id } => {
+            server.handle_websocket_open(&path, channel_id);
+        }
+        HttpServerRequest::WebSocketClose(channel_id) => {
+            server.handle_websocket_close(channel_id);
+        }
+    }
 }
 
 fn local_request<S, T>(
@@ -849,9 +855,8 @@ pub fn no_ws_handler<S>(
     // does nothing
 }
 
-pub fn no_http_api_call<S>(_state: &mut S, _req: ()) -> (http::server::HttpResponse, Vec<u8>) {
-    // trivial 200
-    (http::server::HttpResponse::new(200 as u16), vec![])
+pub fn no_http_api_call<S>(_state: &mut S, _path: &str, _req: ()) {
+    // does nothing
 }
 
 pub fn no_local_request<S>(


### PR DESCRIPTION
- Renamed api to http
- Abstracted away wit bindgen in the erect macro
- Given that we're now making use of http handlers, we shouldn't return a response in the http handler and send it back implicitly, the onus should be on the user, so we remove that
- The http handler now also exposes the path
- Added example illustrating that, just curl the request (see comment in requester code)
- Added more docs
- Added warnings on failed deserializations with utf8 decoding so the user can understand errors better